### PR TITLE
chore: disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Community Discussions
     url: https://community.dataportal.se/


### PR DESCRIPTION
As a test we are trying non blank issues and enhancements as default. This rationale is that if the input format is pre definied it will in the future be easier get oversight and statistics for input. It will guide the reporter to input better data.

If a project has specific needs, they can add their own settings. This was also possible before this, so this just sets the new default.
