### PR TITLE
docs: fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Note that these files are mostly taken from the general [Open Source Project Tem
 
 Most, but not all of the files are licensed under the Creative Commons Zero v1.0 Universal License - see the file headers for details.
 
-CODE_OF_CONDUCT.md is Copyright: [Contributor Covenant](https://www.contributor-covenant.org/)  
+CODE_OF_CONDUCT.md is Copyright: [Contributor Covenant](https://www.contributor-covenant.org/)
  License: [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
 
 Finally, the Digg Logo is *not* under any free usage License.

--- a/docs/how_to_work_github.adoc
+++ b/docs/how_to_work_github.adoc
@@ -1,11 +1,11 @@
 = Hur vi jobbar med Öppen Källkod på GitHub
 Digg Open Source Guild <ospo@digg.se>
-v0.1.7, {docdatetime}
+v0.1.8, {docdatetime}
 :description: A guide for working on Digg's GitHub spaces
 :toc:
 :toclevels: 4
 
-NOTE: Är du aktiv på Digg's GitHub-ytor, läs igenom detta dokument, och <<relevant_links,kompletterande länkar>>.
+NOTE: Är du aktiv på Digg's GitHub-ytor, läs igenom detta dokument, och <<#kompletterande-länkar>>.
 
 == Inledning
 
@@ -16,8 +16,7 @@ Digg har idag två externa samarbetsytor för för öppen källkod och öppna sa
 Där samverkar man kring diverse projekt, både med externa konsulter, bidragsgivare, och Digg-anställda.
 Huvudsakligen ligger där programmeringstunga-projekt, men det förekommer även rena dokumentations- och specifikations-projekt.
 
-[[samarbetsytor]]
-.Huvudsakliga samarbetsytor
+.Samarbetsytor
 [cols="1,1,1,1,1"]
 |===
 | GitHub-Organisation | Samarbetsyta | Syfte | Huvudansvariga | Not
@@ -48,7 +47,7 @@ Enklast brukar vara att bara lägga till <namn@digg.se> till ditt befintliga kon
 
 === Säkerhet för ditt GitHub-konto
 
-* Aktivera 2FA för ditt konto: https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa[Aktivera tvåfaktors autentisering]
+* Aktivera 2FA för ditt konto: https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa[Aktivera tvåfaktors-autentisering]
 * Ta en säkerhetskopia på återställningskoderna som du kan hämta från kontot för din 2FA, och förvara på säkert ställe.
 
 Vidare, om du ska bidra till projekten med Pull Requests och annat:
@@ -90,8 +89,8 @@ En Admin förväntas ha övergripande översikt om sitt Team och dess projekt oc
 * ta ansvar för att agera eller delegera ansvaret för sitt teams/s:
   - säkerhetsvarningar
   - ta bort användare ur teamet som är inaktiva
-* ta ansvar för att projekten arbetar i övrigt för god projekthälsa genom att följa rekommenderade konventioner, (se <<relevant_links,kompletterande länkar>>).
-* vara teamets/ens första kontaktyta med <<samarbetsytor,Owners>>  för adminstrativa spörsmål vid behov.
+* ta ansvar för att projekten arbetar i övrigt för god projekthälsa genom att följa rekommenderade konventioner, (se <<#kompletterande-länkar>>).
+* vara teamets/ens första kontaktyta med <<#inledning,Owners>>  för adminstrativa spörsmål vid behov.
 
 === External Collaborator-rollen
 
@@ -102,13 +101,13 @@ Det ger en mycket bättre separation och översikt över användaren och vilka r
 
 === Hjälpmaterial, rekommendationer, checklista
 
-Digg har tagit fram hjälpmaterial för Öppen Källkod-projekt, i form av interna riktlinjer, checklista samt mall-hjälp, se <<relevant_links,kompletterande länkar>>.
+Digg har tagit fram hjälpmaterial för Öppen Källkod-projekt, i form av interna riktlinjer, checklista samt mall-hjälp, se <<#kompletterande-länkar>>.
 
 === Basmall för GitHub-organisationen DiggSweden
 
 Ett projekt som läggs på DiggSweden's yta kommer att, som förvald standard erhålla generella GitHub-mallar för felrapporter, nya funktioner/förändringar och Pull Requests.
 Anpassa dessa efter projektens behov.
-Vad som är förvalt kan du se i <<relevant_links,Digg's bas för organisationen DiggSweden, under kompletterande länkar>>.
+Vad som är förvalt kan du se i Digg's bas för organisationen DiggSweden, <<#kompletterande-länkar>>.
 
 == Förvaltning och livscykelhantering
 
@@ -122,7 +121,7 @@ Hur team lägger upp det i detalj är upp till Teamet.
 * Att svara på ärenden/issues
 
 I grund och botten är vår GitHub och projektytor avseeda för projektfokuserade ärenden.
-Vi försöker styra undan diskussioner som inte rör projektet direkt till andra ytor (se <<other_links,Dataportalens Communityforum>>).
+Vi försöker styra undan diskussioner som inte rör projektet direkt till andra ytor som Dataportalens Communityforum (se <<#övriga-länkar>>).
 Tveka inte att vidarebeforda frågor till exempelvis Digg's kundtjänst.
 Exempel kan vara frågor som inte är av teknisk karaktär, eller som inte rör projektet mer specifikt.
 
@@ -142,7 +141,7 @@ TIP: Vi är en myndighet, och förväntas av allmänheten besvara vänligt, korr
 
 GitHub bjuder på en mängd verktyg för automatiserade sårbarhet- och säkerhetsgenomsökningar, inklusive beroende-kontroll och statisk kodanalys.
 Vi aktiverar i princip allt som blir tillgängligt inom detta område för GitHub.
-Se <<default_settings,Standardinställningar>> för vilka funktioner som är aktiverade.
+Se <<#förvalda-github-inställningar>> för vilka funktioner som är aktiverade.
 Förinställningarna kan sedan behöva finjusteras av teamet.
 
 TO-DO: Add image of GitHub Security tab
@@ -170,20 +169,16 @@ Ett migrationsarbete pågår här.
 
 == Länkar
 
-[[relevant_links]]
 === Kompletterande länkar
 
 * https://www.digg.se/download/18.72c5e64d183579af3fd1b6c/1664286148293/riktlinjer-for-utveckling-och-publicering-av-oppen-programvara.pdf[Allmänna riktlinjer för Öppen Källkod på Digg]
 * https://github.com/diggsweden/open-source-project-template[Digg’s hjälpmallprojekt för öppen källkod-projekt]
-* https://github.com/diggsweden/open-source-project-template[Digg’s Checklista för öppen källkod-projekt]
+* https://github.com/diggsweden/open-source-project-template/blob/main/docs/Open_Source_Checklist.adoc#the-open-source-release-checklist[Digg’s Checklista för öppen källkod-projekt]
 * https://github.com/diggsweden/.github[Digg’s bas för organisationen DiggSweden]
 
-[[other_links]]
 === Övriga länkar
 * https://community.dataportal.se/[Dataportalens Communityforum - Öppna Data och Öppen Källkod-diskussioner för det offentliga]
 
-
-[appendix]
 == Vanliga frågor (FAQ)
 
 === Team
@@ -199,7 +194,7 @@ En 'Member' kan vara medlem av många team.
 
 * Jag vill forka ett externt projekt, ska jag göra det under Digg's GitHub-organisation eller under min privata användare?
 +
-I de flesta fall så säger vi nej på att lägga forken under Digg-organisationen, forka under din användare i första hand. 
+I de flesta fall så säger vi nej på att lägga forken under Digg-organisationen, forka under din användare i första hand.
 Vi vill inte att organisationen DiggSweden ska ses som att man har tagit på sig att förvalta en fork av något projekt.
 Forkar som ligger under organisationen och inte har diskuteras om i förväg om kommer att arkiveras.
 
@@ -227,9 +222,8 @@ Premissen är dock att privata projekt ska samarbetas om på lämpligare (stäng
 
 * Jag har bara fler frågor nu. Var ska jag vända mig?
 
-Maila i första hand <ospo@digg.se>, i andra hand kontakta någon av <<owners,Owners>> så kan de hjälpa dig vidare.
+Maila i första hand <ospo@digg.se>, i andra hand kontakta någon av <<#inledning,Owners>> så kan de hjälpa dig vidare.
 
-[appendix]
 == Terminologi
 
 .Terminologi i detta dokument
@@ -254,12 +248,10 @@ En rad konfigurerbara processer för att bygga, autotesta, deploya projekt som k
 |===
 
 
-[appendix]
-[[default_settings]]
-== Översikt av förvalda GitHub-inställningar (DiggSweden)
+== Förvalda GitHub-inställningar
 
 GitHub har flera bra funktioner för säkerhet, adminstration och förvaltning, och många av dessa måste aktiveras.
-Detta avsnitt beskriver en del av de inställningar som är aktiverade.
+Detta avsnitt beskriver en del av de inställningar som är aktiverade på DiggSweden.
 
 Syftet är inte att dokumentera alla detaljinställningar i tabellen, men att ge en översikt så att användare förstår vilka möjligheter de har i sina projekt.
 
@@ -304,3 +296,4 @@ Syftet är inte att dokumentera alla detaljinställningar i tabellen, men att ge
 |===
 
 CAUTION: Flera av de beskrivna inställningarna gäller inte om du använder privata repositories, då det kräver en betalplan för GitHub.
+

--- a/profile/README.md
+++ b/profile/README.md
@@ -29,45 +29,45 @@ If you are looking for Open Data and deeper community discussions about open res
 
 A list of interesting Digg and friends projects:
 
-## :ballot_box_with_check: Guidelines 
+## :ballot_box_with_check: Guidelines
 
-- [Digg's internal guidelines about Open Source (in Swedish only)](https://www.digg.se/analys-och-uppfoljning/publikationer/publikationer/2022-09-27-anskaffning-utveckling-och-publicering-av-oppen-programvara-policy-och-riktlinjer)    
+- [Digg's internal guidelines about Open Source (in Swedish only)](https://www.digg.se/analys-och-uppfoljning/publikationer/publikationer/2022-09-27-anskaffning-utveckling-och-publicering-av-oppen-programvara-policy-och-riktlinjer)
 Digg's guidelines about Open Source software.
 
-- [Digg's recommendations about Open licenses, Open Data and more (in Swedish only)](https://www.digg.se/kunskap-och-stod/oppna-och-delade-data/offentliga-aktorer)    
+- [Digg's recommendations about Open licenses, Open Data and more (in Swedish only)](https://www.digg.se/kunskap-och-stod/oppna-och-delade-data/offentliga-aktorer)
 Digg's recommendations about licenses for open resources.
 
-- [Digg’s helper template project for Open Source projects](https://github.com/diggsweden/open-source-project-template)  
+- [Digg’s helper template project for Open Source projects](https://github.com/diggsweden/open-source-project-template)
 A helper project with templates for releasing an Open Source Project.
 
 - [Digg’s checklist for Open Source projects](https://github.com/diggsweden/open-source-project-template/blob/main/docs/Open_Source_Checklist.adoc)
 A checklist for the release of Open Source projects.
 
-- [How to work on Digg's GitHub (in Swedish only)](https://github.com/diggsweden/.github/blob/main/docs/how_to_work_github.adoc)  
+- [How to work on Digg's GitHub (in Swedish only)](https://github.com/diggsweden/.github/blob/main/docs/how_to_work_github.adoc)
 A guide for anyone working on Digg's GitHub.
 
 ## :cyclone: Open Data
 
-- [The Swedish Dataportal](https://www.dataportal.se/en)    
+- [The Swedish Dataportal](https://www.dataportal.se/en)
 Open Data and Community Discussion portal regarding all things open.
 
 ## :performing_arts: Digital identity and friends
 
-- [Sweden Connect](https://swedenconnect.se/en)    
+- [Sweden Connect](https://swedenconnect.se/en)
 Sweden's connection point for eIDAS and contains functions for electronic identification.
 
-- [Sweden Connect GitHub](https://github.com/swedenconnect)  
+- [Sweden Connect GitHub](https://github.com/swedenconnect)
 The Open Source software behind Sweden Connect.
 
 ## :vulcan_salute: Friends
 
-- **asom**  
+- **asom**
 A Swedish collaborative forum among various government agencies, created with the aim of promoting practical releases, contributions, and collaboration regarding Open Source solutions.
 
-- [NOSAD (in Swedish only)](https://nosad.se)   
+- [NOSAD (in Swedish only)](https://nosad.se)
 Network for Open Source and Data in the public sector.
 
-- [Offentlig kod (in Swedish only)](https://offentligkod.se)  
+- [Offentlig kod (in Swedish only)](https://offentligkod.se)
 A searchable catalogue of Open Source Software used in the public sector, with contribution possibilities.
 
 ## :hammer: Tooling
@@ -101,7 +101,7 @@ A searchable catalogue of Open Source Software used in the public sector, with c
 
 Välkommen till Digg's GitHub. Här hittar du våra projekt som är öppen källkod :heart:.
 
-För att skapa ett hållbart välfärdssamhälle behöver digitaliseringen av Sverige intensifieras. Därför finns [Digg](https://www.digg.se/om-oss). 
+För att skapa ett hållbart välfärdssamhälle behöver digitaliseringen av Sverige intensifieras. Därför finns [Digg](https://www.digg.se/om-oss).
 Tillsammans med hela den offentliga förvaltningen arbetar vi för att omställningen ska bli verklighet, och till nytta för alla.
 
 Är du ute efter själva programkoden - att använda, bidra, granska - så har du kommit rätt!
@@ -112,44 +112,44 @@ Intressanta Digg-relaterade projekt och länkar:
 
 ## :ballot_box_with_check: Om Digg och Öppen Källkod
 
-- [Digg's interna riktlinjer för öppen källkod](https://www.digg.se/analys-och-uppfoljning/publikationer/publikationer/2022-09-27-anskaffning-utveckling-och-publicering-av-oppen-programvara-policy-och-riktlinjer)    
+- [Digg's interna riktlinjer för öppen källkod](https://www.digg.se/analys-och-uppfoljning/publikationer/publikationer/2022-09-27-anskaffning-utveckling-och-publicering-av-oppen-programvara-policy-och-riktlinjer)
 Digg's interna riktlinjer för öppen källkod.
 
-- [Digg's rekommendationer kring övriga öppna licenser, öppna data ](https://www.digg.se/kunskap-och-stod/oppna-och-delade-data/offentliga-aktorer)    
+- [Digg's rekommendationer kring övriga öppna licenser, öppna data ](https://www.digg.se/kunskap-och-stod/oppna-och-delade-data/offentliga-aktorer)
 Digg's rekommendationer för licenser av öppna data och andra resurser än källkod.
 
-- [Digg’s hjälpmallprojekt för öppen källkod-projekt](https://github.com/diggsweden/open-source-project-template)  
+- [Digg’s hjälpmallprojekt för öppen källkod-projekt](https://github.com/diggsweden/open-source-project-template)
 Ett hjälpprojekt för när man ska ska släppa ett öppen källkod-projekt.
 
-- [Digg’s checklista för öppen källkod-projekt](https://github.com/diggsweden/open-source-project-template/blob/main/docs/Open_Source_Checklist.adoc)  
+- [Digg’s checklista för öppen källkod-projekt](https://github.com/diggsweden/open-source-project-template/blob/main/docs/Open_Source_Checklist.adoc)
 En checklista inför släpp av öppen källkodprojekt.
 
-- [Hur vi jobbar på Digg's GitHub](https://github.com/diggsweden/.github/blob/main/docs/how_to_work_github.adoc)  
+- [Hur vi jobbar på Digg's GitHub](https://github.com/diggsweden/.github/blob/main/docs/how_to_work_github.adoc)
 En guide för den som ska jobba på Digg's GitHub
 
 ## :cyclone: Öppna data
 
-- [Sveriges Dataportal](https://www.dataportal.se/)    
+- [Sveriges Dataportal](https://www.dataportal.se/)
 Portal och diskussionsforum för öppna data, öppen källkod och övrigt öppet i offentlig sektor.
 
 
-## :performing_arts: Digital Identitet 
+## :performing_arts: Digital Identitet
 
-- [Sweden Connect](https://swedenconnect.se)  
+- [Sweden Connect](https://swedenconnect.se)
 För dig som vill ansluta e-tjänster för att få tillgång till inloggning med svenska och utländska e-legitimationer.
 
-- [Sweden Connect GitHub](https://github.com/swedenconnect)  
+- [Sweden Connect GitHub](https://github.com/swedenconnect)
 Programkod och projekt för Sweden Connect.
 
 ## :vulcan_salute: Vänner
 
-- **asom** (arbetsgruppen för samordning mjukvara)  
+- **asom** (arbetsgruppen för samordning mjukvara)
 Ett samverkansforum mellan olika myndigheter, som uppstod i syftet att främja praktiska släpp, bidrag och samverkan kring Öppen Källkods-lösningar.
 
-- [NOSAD](https://nosad.se)   
+- [NOSAD](https://nosad.se)
 Nätverket för öppna data och öppen källkod inom det offentliga.
 
-- [Offentlig kod](https://offentligkod.se)  
+- [Offentlig kod](https://offentligkod.se)
 En sökbar katalog över öppen källkods-projekt som används inom offentlig sektor. Bidra och förbättra.
 
 ## :hammer: Verktyg


### PR DESCRIPTION
Fixes a few non working links in the how to github-doc, and removes a few extra whitespaces.

Fixes #3 

