### PR TITLE
docs(how-to): add clearification regarding digg build

### DIFF
--- a/docs/how_to_work_github.adoc
+++ b/docs/how_to_work_github.adoc
@@ -16,6 +16,9 @@ Digg har idag två externa samarbetsytor för för öppen källkod och öppna sa
 Där samverkar man kring diverse projekt, både med externa konsulter, bidragsgivare, och Digg-anställda.
 Huvudsakligen ligger där programmeringstunga-projekt, men det förekommer även rena dokumentations- och specifikations-projekt.
 
+NOTE: Vad gäller Öppen Källkod-projekten på Digg’s GitHub-ytor, som tas fram på direkt beställning av Digg och är direkt avsedd för deployment på Digg’s drifts-miljöer gäller att projektet också SKA kunna byggas och deployas i Digg's interna miljöer. Se i det fallet intern Digg-utvecklardokumentation (utvecklarhandbok) för detaljer.
+
+
 .Samarbetsytor
 [cols="1,1,1,1,1"]
 |===


### PR DESCRIPTION
Add clearification of build expectations of open source projects, that are explicitly ordered and intended for Digg internal purposes. As discussed with el, ss.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
