### PR TITLE
ci: add reusable flows for publiccode and mise just lint

### DIFF
--- a/.github/workflows/misc-lint.yml
+++ b/.github/workflows/misc-lint.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 The Open Source Project Template Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+name: Mise And Just Verify
+on: [workflow_call]
+permissions:
+  contents: read
+jobs:
+  quality-checks:
+    name: Quality Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          fetch-depth: 0 # Needed for commit linting
+      - name: Setup mise
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+        with:
+          install: true
+          cache: true
+          experimental: true # Required for go backend tools
+      - name: Install mise tools
+        run: |
+          mise install
+          mise list
+      - name: Just Verify
+        run: |
+          # Activate mise to get tools in PATH
+          eval "$(mise activate bash)"
+          # Run verification
+          just lint
+

--- a/.github/workflows/publiccode-lint.yml
+++ b/.github/workflows/publiccode-lint.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 The Open Source Project Template Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+name: Lint Public Code MetaData
+on: [workflow_call] # yamllint disable-line rule:truthy
+permissions:
+  contents: read
+jobs:
+  publiccode_validation:
+    name: publiccode validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: italia/publiccode-parser-action@3244a5a109ae23f76cb379831abbad32927cad8c # v1.2.0
+        with:
+          publiccode: "publiccode.yml"
+

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Some GitHub Workflows can be reused in other projects, see the '.github/workflow
 - CommitLint
 - DependencyAnalysis
 - LicenseLint
-- MegaLint - Lint Containers, scripts, code
+- MegaLint - Lint Containers, scripts, code (to be deprecated use misc lint instead)
+- Misc Lint - Mise and Just lint setup 
+- Public Code Lint - Verify that the project has a valid public code yaml
 - OpenSSF-Scorecard - Projecthealth from a security perspective 
 - Versionbump and Changelog - generate a Changelog, in a commit Release, bump project version
 


### PR DESCRIPTION
This adds two reuseable ci flows, one for publiccode and one for mise just lint.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
