### PR TITLE
feat: change semantic commit type from chore to build

### DIFF
--- a/renovate-base.json
+++ b/renovate-base.json
@@ -14,7 +14,7 @@
     ":semanticCommits",
     ":rebaseStalePrs",
     "mergeConfidence:all-badges",
-    ":semanticCommitTypeAll(chore)"
+    ":semanticCommitTypeAll(build)"
   ],
   "semanticCommitScope": "deps",
   "commitMessageLowerCase": "auto",


### PR DESCRIPTION
Chores are often filtered out but dependency upgrades can be crucial information
